### PR TITLE
make nginx dependent on containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,10 @@ services:
       - '/PATH/TO/dnpm-server-key.pem:/etc/ssl/certs/dnpm-server-key.pem'   # Server private key
       - '/PATH/TO/dnpm-client-cert.pem:/etc/ssl/certs/dnpm-client-cert.pem' # Client certificate
       - '/PATH/TO/dnpm-client-key.pem:/etc/ssl/certs/dnpm-client-key.pem'   # Client private key
+    depends_on:
+      - authup
+      - portal
+      - backend
     networks:
       dnpm:
 


### PR DESCRIPTION
On start ngnix has an error message, because not all of the required containers are yet existing. 
As the nginx.conf refers to `authup`, `portal` and `backend` those should exist before nginx, so that dns resolution would work correctly.